### PR TITLE
Only install Clang 6.0 tools in the Starling toolchain

### DIFF
--- a/starling-toolchain.rb
+++ b/starling-toolchain.rb
@@ -3,29 +3,20 @@ class StarlingToolchain < Formula
   homepage "https://github.com/swift-nav/starling"
   url "http://releases.llvm.org/6.0.0/clang+llvm-6.0.0-x86_64-apple-darwin.tar.xz"
   sha256 "0ef8e99e9c9b262a53ab8f2821e2391d041615dd3f3ff36fdf5370916b0f4268"
-  version "1.3.0"
+  version "1.4.0"
 
   bottle :unneeded
 
-  resource "llvm-4.0" do
-    url "http://releases.llvm.org/4.0.0/clang+llvm-4.0.0-x86_64-apple-darwin.tar.xz"
-    sha256 "5504064916d0651c185ceff85871298f31e2eaf4abf1333b2c36f5eed5e9cde6"
-  end
-
   def install
+    # Also install clang-format and clang-tidy with version names
+    cp "bin/clang-format", "bin/clang-format-6.0"
+    cp "bin/clang-tidy", "bin/clang-tidy-6.0"
+
     # Install the entire LLVM 6.0 toolchain
     bin.install Dir["bin/*"]
     include.install Dir["include/*"]
     lib.install Dir["lib/*"]
     libexec.install Dir["libexec/*"]
     share.install Dir["share/*"]
-
-    # Install clang-format and clang-tidy from LLVM 4.0 only
-    (buildpath/"llvm-4.0").install resource("llvm-4.0")
-    mv buildpath/"llvm-4.0/bin/clang-format", buildpath/"llvm-4.0/bin/clang-format-4.0"
-    mv buildpath/"llvm-4.0/bin/clang-tidy", buildpath/"llvm-4.0/bin/clang-tidy-4.0"
-
-    bin.install buildpath/"llvm-4.0/bin/clang-format-4.0"
-    bin.install buildpath/"llvm-4.0/bin/clang-tidy-4.0"
   end
 end


### PR DESCRIPTION
Remove installation of Clang 4.0 format and tidy tools. Duplicate installation of Clang 6.0 tools with `-6.0` appended to their names.

Note that this effectively makes the `starling-toolchain` formula a Clang 6.0 installer, since no other tools are installed for the time being.