### PR TITLE
Add more toolchain components

### DIFF
--- a/starling-clang-tools.rb
+++ b/starling-clang-tools.rb
@@ -4,12 +4,15 @@ class StarlingClangTools < Formula
   url "file:///dev/null"
   sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
   version "1.0.0"
-  
+
   depends_on "llvm@6"
 
   bottle :unneeded
 
   def install
-    bin.install_symlink "/usr/local/opt/llvm@6/bin/clang-format" => "clang-format-6.0", "/usr/local/opt/llvm@6/bin/clang-tidy" => "clang-tidy-6.0"
+    bin.install_symlink "/usr/local/opt/llvm@6/bin/clang-format" => "clang-format-6.0", 
+                        "/usr/local/opt/llvm@6/bin/clang-tidy" => "clang-tidy-6.0",
+                        "/usr/local/opt/llvm@6/bin/llvm-cov" => "llvm-cov"
+    
   end
 end

--- a/starling-clang-tools.rb
+++ b/starling-clang-tools.rb
@@ -4,6 +4,7 @@ class StarlingClangTools < Formula
   url "file:///dev/null"
   sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
   version "1.0.0"
+  
   depends_on "llvm@6"
 
   bottle :unneeded

--- a/starling-clang-tools.rb
+++ b/starling-clang-tools.rb
@@ -3,7 +3,7 @@ class StarlingClangTools < Formula
   homepage "https://github.com/swift-nav/starling"
   url "file:///dev/null"
   sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-  version "1.0.0"
+  version "2.0.0"
 
   depends_on "llvm@6"
 

--- a/starling-python-tools.rb
+++ b/starling-python-tools.rb
@@ -11,4 +11,10 @@ class StarlingPythonTools < Formula
     depends_on "pipenv"
   
     bottle :unneeded
+
+    def install
+        (doc/"README").write <<~EOS
+          Check out the Starling repository README for details on the starling project. https://github.com/swift-nav/starling
+        EOS
+    end
 end

--- a/starling-python-tools.rb
+++ b/starling-python-tools.rb
@@ -11,7 +11,4 @@ class StarlingPythonTools < Formula
     depends_on "pipenv"
   
     bottle :unneeded
-  
-    def install
-    end
 end

--- a/starling-python-tools.rb
+++ b/starling-python-tools.rb
@@ -1,4 +1,4 @@
-class StarlinPythonTools < Formula
+class StarlingPythonTools < Formula
     desc "Quick install of the Starling development python toolchain"
     homepage "https://github.com/swift-nav/starling"
     url "file:///dev/null"

--- a/starling-python-tools.rb
+++ b/starling-python-tools.rb
@@ -1,0 +1,17 @@
+class StarlinPythonTools < Formula
+    desc "Quick install of the Starling development python toolchain"
+    homepage "https://github.com/swift-nav/starling"
+    url "file:///dev/null"
+    
+    sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    
+    version "1.0.0"
+  
+    depends_on "pyenv"
+    depends_on "pipenv"
+  
+    bottle :unneeded
+  
+    def install
+    end
+end

--- a/starling-toolchain.rb
+++ b/starling-toolchain.rb
@@ -6,7 +6,10 @@ class StarlingToolchain < Formula
   version "2.0.0"
 
   depends_on "starling-clang-tools"
+  depends_on "starling-python-tools"
   depends_on "check"
+  depends_on "gh"
+  depends_on "cmake"
 
   bottle :unneeded
 

--- a/starling-toolchain.rb
+++ b/starling-toolchain.rb
@@ -3,7 +3,7 @@ class StarlingToolchain < Formula
   homepage "https://github.com/swift-nav/starling"
   url "file:///dev/null"
   sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-  version "2.0.0"
+  version "3.0.0"
 
   depends_on "starling-clang-tools"
   depends_on "starling-python-tools"

--- a/swiftlets-toolchain.rb
+++ b/swiftlets-toolchain.rb
@@ -1,0 +1,18 @@
+class SwiftletsToolchain < Formula
+    desc "Quick install of the Starling development toolchain"
+    homepage "https://github.com/swift-nav/starling"
+    url "file:///dev/null"
+    sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    version "2.0.0"
+  
+    depends_on "starling-toolchain"
+    depends_on "protobuf"
+  
+    bottle :unneeded
+  
+    def install
+      (doc/"README").write <<~EOS
+        Check out the Starling repository README for details on the starling project. https://github.com/swift-nav/starling
+      EOS
+    end
+  end

--- a/swiftlets-toolchain.rb
+++ b/swiftlets-toolchain.rb
@@ -3,7 +3,7 @@ class SwiftletsToolchain < Formula
     homepage "https://github.com/swift-nav/starling"
     url "file:///dev/null"
     sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-    version "2.0.0"
+    version "1.0.0"
   
     depends_on "starling-toolchain"
     depends_on "protobuf"


### PR DESCRIPTION
This PR adds more components to the available formulas:

- protobuf for swiftlets
- pyenv / pipenv for installing python dependencies (see also https://github.com/swift-nav/starling/pull/4030 and https://github.com/swift-nav/swiftlets/pull/1112)
- Symlink for `llvm-cov` to enable coverage (see https://swift-nav.atlassian.net/l/c/1fqZA0Eh)